### PR TITLE
Fixed c-buttons and add Minus button combo.

### DIFF
--- a/include/N64Controller.h
+++ b/include/N64Controller.h
@@ -46,8 +46,19 @@ class N64Controller : public Controller {
 #define N64_MASK_DPAD_UPLEFT 0xA
 
 #define N64_MASK_C_UP 0x8
-#define N64_MASK_C_DOWN 0x4
-#define N64_MASK_C_LEFT 0x2
+#define N64_MASK_C_UPRIGHT 0x9
 #define N64_MASK_C_RIGHT 0x1
+#define N64_MASK_C_DOWNRIGHT 0x5
+#define N64_MASK_C_DOWN 0x4
+#define N64_MASK_C_DOWNLEFT 0x6
+#define N64_MASK_C_LEFT 0x2
+#define N64_MASK_C_UPLEFT 0xA
+#define N64_MASK_C_UPDOWN 0xC
+#define N64_MASK_C_LEFTRIGHT 0x3
+#define N64_MASK_C_UPDOWNLEFT 0xE
+#define N64_MASK_C_UPDOWNRIGHT 0xD
+#define N64_MASK_C_UPLEFTRIGHT 0xB
+#define N64_MASK_C_DOWNLEFTRIGHT 0x7
+#define N64_MASK_C_UPDOWNLEFTRIGHT 0xF
 
 #endif

--- a/src/otherController/n64/N64Controller.cpp
+++ b/src/otherController/n64/N64Controller.cpp
@@ -61,7 +61,8 @@ void N64Controller::getSwitchReport(SwitchReport *switchReport) {
 
   switchReport->buttons[1] =
       (N64_MASK_RESET & _controllerState[1] ? SWITCH_MASK_HOME : 0) |
-      (N64_MASK_START & _controllerState[0] ? SWITCH_MASK_PLUS : 0);
+      (N64_MASK_START & _controllerState[0] ? SWITCH_MASK_PLUS : 0) |
+      ((N64_MASK_L  & _controllerState[1] - N64_MASK_R & _controllerState[1]) & (N64_MASK_Z & _controllerState[0]) ? SWITCH_MASK_MINUS : 0);
 
   switchReport->buttons[2] = 0x00;
   switch (N64_MASK_DPAD & _controllerState[0]) {
@@ -110,12 +111,64 @@ void N64Controller::getSwitchReport(SwitchReport *switchReport) {
       break;
     case N64_MASK_C_DOWN:
       ry = SWITCH_JOYSTICK_MIN;
+      //switchReport->buttons[0] = SWITCH_MASK_X;
       break;
     case N64_MASK_C_LEFT:
       rx = SWITCH_JOYSTICK_MIN;
+      //switchReport->buttons[0] = SWITCH_MASK_Y;
       break;
     case N64_MASK_C_RIGHT:
       rx = SWITCH_JOYSTICK_MAX;
+      break;
+    case N64_MASK_C_UPLEFT:
+      rx = SWITCH_JOYSTICK_MIN;
+      ry = SWITCH_JOYSTICK_MAX;
+      break;
+    case N64_MASK_C_DOWNLEFT:
+      rx = SWITCH_JOYSTICK_MIN;
+      ry = SWITCH_JOYSTICK_MIN;
+      //switchReport->buttons[0] = SWITCH_MASK_X + SWITCH_MASK_Y;
+      break;
+    case N64_MASK_C_UPRIGHT:
+      rx = SWITCH_JOYSTICK_MAX;
+      ry = SWITCH_JOYSTICK_MAX;
+      break;
+    case N64_MASK_C_DOWNRIGHT:
+      rx = SWITCH_JOYSTICK_MAX;
+      ry = SWITCH_JOYSTICK_MIN;
+      break;
+    case N64_MASK_C_UPDOWN:
+      ry = SWITCH_JOYSTICK_MAX;
+      switchReport->buttons[0] = SWITCH_MASK_X;
+      break;
+    case N64_MASK_C_LEFTRIGHT:
+      rx = SWITCH_JOYSTICK_MAX;
+      switchReport->buttons[0] = SWITCH_MASK_Y;
+      break;
+    case N64_MASK_C_UPDOWNLEFT:
+      rx = SWITCH_JOYSTICK_MIN;
+      ry = SWITCH_JOYSTICK_MAX;
+      switchReport->buttons[0] = SWITCH_MASK_X;
+      break;
+    case N64_MASK_C_UPDOWNRIGHT:
+      rx = SWITCH_JOYSTICK_MAX;
+      ry = SWITCH_JOYSTICK_MAX;
+      switchReport->buttons[0] = SWITCH_MASK_X;
+      break;
+    case N64_MASK_C_UPLEFTRIGHT:
+      rx = SWITCH_JOYSTICK_MAX;
+      ry = SWITCH_JOYSTICK_MAX;
+      switchReport->buttons[0] = SWITCH_MASK_Y;
+      break;
+    case N64_MASK_C_DOWNLEFTRIGHT:
+      rx = SWITCH_JOYSTICK_MAX;
+      ry = SWITCH_JOYSTICK_MIN;
+      switchReport->buttons[0] = SWITCH_MASK_Y;
+      break;
+    case N64_MASK_C_UPDOWNLEFTRIGHT:
+      rx = SWITCH_JOYSTICK_MAX;
+      ry = SWITCH_JOYSTICK_MAX;
+      switchReport->buttons[0] = SWITCH_MASK_X + SWITCH_MASK_Y;
       break;
   }
   switchReport->r[0] = rx & 0xff;

--- a/src/otherController/n64/N64Controller.cpp
+++ b/src/otherController/n64/N64Controller.cpp
@@ -111,11 +111,9 @@ void N64Controller::getSwitchReport(SwitchReport *switchReport) {
       break;
     case N64_MASK_C_DOWN:
       ry = SWITCH_JOYSTICK_MIN;
-      //switchReport->buttons[0] = SWITCH_MASK_X;
       break;
     case N64_MASK_C_LEFT:
       rx = SWITCH_JOYSTICK_MIN;
-      //switchReport->buttons[0] = SWITCH_MASK_Y;
       break;
     case N64_MASK_C_RIGHT:
       rx = SWITCH_JOYSTICK_MAX;
@@ -127,7 +125,6 @@ void N64Controller::getSwitchReport(SwitchReport *switchReport) {
     case N64_MASK_C_DOWNLEFT:
       rx = SWITCH_JOYSTICK_MIN;
       ry = SWITCH_JOYSTICK_MIN;
-      //switchReport->buttons[0] = SWITCH_MASK_X + SWITCH_MASK_Y;
       break;
     case N64_MASK_C_UPRIGHT:
       rx = SWITCH_JOYSTICK_MAX;


### PR DESCRIPTION
Added the missing C-Button directions and even allowed opposite directions.
opposite directions are handled as follow:
- pressing C-UP and C-DOWN outputs C-UP and the X button.
- pressing C-LEFT and C-RIGHT outputs C-RIGHT and the Y button.

Also added a button combo to press the Minus button.
- pressing the L, R and Z button at the same time outputs the Minus button to access the NSO menu.

It is untested on Switch since i don't own one, but it works great on PC.