### PR TITLE
Add dockerfile for building.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Docker Image Based on https://github.com/lukstep/raspberry-pi-pico-docker-sdk
+FROM ubuntu:24.10 as build
+
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install --no-install-recommends -y \
+                       git \
+                       ca-certificates \
+                       python3 \
+                       tar \
+                       build-essential \
+                       gcc-arm-none-eabi \
+                       libnewlib-arm-none-eabi \
+                       libstdc++-arm-none-eabi-newlib \
+                       cmake && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Raspberry Pi Pico SDK
+ARG SDK_PATH=/usr/local/picosdk
+RUN git clone --depth 1 --branch 2.0.0 https://github.com/raspberrypi/pico-sdk $SDK_PATH && \
+    cd $SDK_PATH && \
+    git submodule update --init
+
+ENV PICO_SDK_PATH=$SDK_PATH
+
+# Build the Project
+RUN mkdir /app
+WORKDIR /app
+COPY . .
+
+RUN cmake -B build -DPICO_BOARD=pico_w -S .
+RUN make -C build/
+
+# Separate the Binaries for Exporting
+FROM scratch
+COPY --from=build /app/build/src/retro_pico_switch.uf2 /

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [Bluetooth](#bluetooth)
 - [Setup](#setup)
 - [3D Printed Enclosure/Plug](#3d-printed-enclosureplug)
+- [Building with Docker](#building-with-docker)
 - [Credits](#credits)
 
 ---
@@ -61,6 +62,19 @@ I've also designed a small enclosure to house the Pico and act as a plug for a s
   <img width="400" src="resources/N64%20Male%20Connector.jpg"/>
   <img width="400" src="resources/Pico%20Enclosure.jpg"/>
 </a>
+
+## Building with Docker
+
+Having docker installed you can build this project yourself by simply running
+the command:
+
+```
+docker build --output=./build .
+```
+
+The docker file in this project will install all necessary dependencies and run
+the commands necessary to build this project. In the end the generated binary is
+exported to the output folder of the command: "./build"
 
 ## Credits
 


### PR DESCRIPTION
After having trouble building this project myself due to lack of experience with RPi Pico I found a docker image that helped me find the proper way to build this.

Here is a minimal version of the docker image that allows this project to build in any machine that has docker without having to install the proper dependencies in the host machine.