### PR TITLE
Fix manual build flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 3.25.1)
 
+if (NOT PICO_BOARD)
+    set(PICO_BOARD pico_w)
+endif()
 include($ENV{PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 include($ENV{PICO_SDK_PATH}/tools/CMakeLists.txt)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 set(PICO_CXX_ENABLE_EXCEPTIONS 1)
-set(PICO_BOARD pico_w)
 
 project(retro_pico_switch C CXX ASM)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ The docker file in this project will install all necessary dependencies and run
 the commands necessary to build this project. In the end the generated binary is
 exported to the output folder of the command: "./build"
 
+## Building with the Pico SDK
+
+The Pico SDK must be available at some given location [^1]. In this Linux example, tested with Pico SDK 2.2.0, it is specified by the `PICO_SDK_PATH` environment variable.
+
+```sh
+export PICO_SDK_PATH=/home/user/pico/pico-sdk # as an example
+
+# for Pico W with Bluetooth support
+cmake -B build -DPICO_BOARD=pico_w
+make -C build/
+
+# for Pico with USB only
+cmake -B build -DPICO_BOARD=pico
+make -C build/
+```
+
+[^1]: See "Manually Configure your Environment" in Appendix C of the "Getting started with Raspberry Pi Pico-series" document
+
 ## Credits
 
 This project would have taken a lot longer without the work done by everyone credited in the original [N64-Arduino-Switch](https://github.com/DavidPagels/n64-arduino-switch) project along with the creators and contributors of [TinyUsb](https://github.com/hathach/tinyusb), the [GP2040-CE](https://github.com/OpenStickCommunity/GP2040-CE) project, and the [MPG](https://github.com/OpenStickCommunity/MPG) project. Figuring out how to interface via Bluetooth also took me 1.5 months of work in my off time and would have taken even longer without the work done by Brikwerk on the [nxbt](https://github.com/Brikwerk/nxbt) project. If you're into developing this sort of stuff, definitely check their stuff out!

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,18 @@
 # Options:
 # SWITCH_BLUETOOTH: Remove for USB
-add_compile_definitions(SWITCH_BLUETOOTH)
+if (PICO_BOARD STREQUAL "pico_w")
+    add_compile_definitions(SWITCH_BLUETOOTH)
+endif()
 add_subdirectory(otherController)
 add_subdirectory(switchController)
 
 add_executable(${PROJECT_NAME} main.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(${PROJECT_NAME} pico_stdlib switchBluetooth switchUsb n64 gamecube)
+if (PICO_BOARD STREQUAL "pico_w")
+    target_link_libraries(${PROJECT_NAME} pico_stdlib switchBluetooth switchUsb n64 gamecube)
+else()
+    target_link_libraries(${PROJECT_NAME} pico_stdlib switchUsb n64 gamecube)
+endif()
 
 pico_enable_stdio_usb(${PROJECT_NAME} 0)
 pico_enable_stdio_uart(${PROJECT_NAME} 1)

--- a/src/switchController/CMakeLists.txt
+++ b/src/switchController/CMakeLists.txt
@@ -2,15 +2,17 @@ add_library(switchUsb SwitchUsb.cpp SwitchCommon.cpp)
 target_link_libraries(switchUsb pico_stdlib pico_rand hardware_pio tinyusb_device)
 target_include_directories(switchUsb PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-add_library(switchBluetooth SwitchBluetooth.cpp SwitchCommon.cpp)
-target_link_libraries(switchBluetooth 
-  pico_stdlib
-  pico_rand
-  pico_btstack_cyw43
-  pico_btstack_hci_transport_cyw43
-  pico_btstack_ble
-  pico_btstack_classic
-  pico_cyw43_arch_threadsafe_background
-  )
-target_compile_definitions(switchBluetooth PUBLIC CYW43_LWIP=0)
-target_include_directories(switchBluetooth PUBLIC ${PROJECT_SOURCE_DIR}/include)
+if (PICO_BOARD STREQUAL "pico_w")
+    add_library(switchBluetooth SwitchBluetooth.cpp SwitchCommon.cpp)
+    target_link_libraries(switchBluetooth 
+      pico_stdlib
+      pico_rand
+      pico_btstack_cyw43
+      pico_btstack_hci_transport_cyw43
+      pico_btstack_ble
+      pico_btstack_classic
+      pico_cyw43_arch_threadsafe_background
+      )
+    target_compile_definitions(switchBluetooth PUBLIC CYW43_LWIP=0)
+    target_include_directories(switchBluetooth PUBLIC ${PROJECT_SOURCE_DIR}/include)
+endif()


### PR DESCRIPTION
The build was only working with `-DPICO_BOARD=pico_w` explicitly specified.

The `set(PICO_BOARD pico_w)` statement came after the inclusion of the Pico SDK in the root CMakeLists.txt. The Pico SDK then assumed the plain `pico` as a default, omitting Bluetooth-related components.

Specifying `-DPICO_BOARD=pico` did not work because the switchBluetooth component was being built unconditionally.

Disclaimer: I am not familiar with CMake and used Gemini 3 Flash for assistance, which was at least partially helpful in figuring out what's wrong :shrug: 

btw super cool project!